### PR TITLE
Resolve sym link before simplifying the path name

### DIFF
--- a/plugin/vimix.vim
+++ b/plugin/vimix.vim
@@ -14,7 +14,7 @@ function! s:VimixFindMixRoot(dir)
       return 0
       call s:error("mix.exs file not found in project")
     else
-      let dir = simplify(dir.'/..')
+      let dir = simplify(resolve(dir).'/..')
     endif
   endwhile
   return dir


### PR DESCRIPTION
`vim /path/to/symlink/` would stall on my MacOS.
