### PR TITLE
Use shellescape function for file paths

### DIFF
--- a/plugin/vimix.vim
+++ b/plugin/vimix.vim
@@ -34,7 +34,8 @@ if g:vimix_map_keys
   nnoremap <Leader>mds :call VimixDepsStatus()<CR>
   nnoremap <Leader>mdU :call VimixDepsUpdate()<CR>
   nnoremap <Leader>mL :call VimixLocal()<CR>
-  nnoremap <Leader>mr :call VimixlocalCommand()<CR>
+  nnoremap <Leader>mr :call VimixPromptCommand()<CR>
+  nnoremap <Leader>mm :call VimuxRunLastCommand()<CR>
 endif
 
 function VimixTestAll()


### PR DESCRIPTION
Thanks for this plugin!

I was having an issue running focused tests in directories with parenthesis in the path name.  I was able to fix my issue by using `shellescape` when trying to call files and change directories.  

See: http://vimdoc.sourceforge.net/htmldoc/eval.html#shellescape()

I also added some keybindings that were in the README but not the plugin
