### PR TITLE
Add VimixTestCurrentLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Here are the key mappings for your reference:
 | ------------- | -------------------- | -----------
 | \<Leader\>mT  | VimixTestAll         | test
 | \<Leader\>mt  | VimixTestCurrentFile | test \<test file\>
+| \<Leader\>ml  | VimixTestCurrentLine | test \<test file\>:\<test line\>
 | \<Leader\>mc  | VimixCompile         | compile
 | \<Leader\>mC  | VimixClean           | clean
 | \<Leader\>mdc | VimixDepsCompile     | deps.compile

--- a/plugin/vimix.vim
+++ b/plugin/vimix.vim
@@ -27,6 +27,7 @@ endif
 if g:vimix_map_keys
   nnoremap <Leader>mT :call VimixTestAll()<CR>
   nnoremap <Leader>mt :call VimixTestCurrentFile()<CR>
+  nnoremap <Leader>ml :call VimixTestCurrentLine()<CR>
   nnoremap <Leader>mc :call VimixCompile()<CR>
   nnoremap <Leader>mC :call VimixClean()<CR>
   nnoremap <Leader>mdc :call VimixDepsCompile()<CR>
@@ -46,6 +47,12 @@ function VimixTestCurrentFile()
   let test_file = s:TestFor(expand('%:p'))
   echo test_file
   call s:VimixRunCommand("test ".shellescape(test_file, 1))
+endfunction
+
+function VimixTestCurrentLine()
+  let test_file_with_line = s:TestWithLineFor(expand('%:p'))
+  echo test_file_with_line
+  call s:VimixRunCommand("test ".shellescape(test_file_with_line, 1))
 endfunction
 
 function VimixClean()
@@ -96,6 +103,15 @@ function s:TestFor(file)
     return l:file
   else
     call s:error("can't find a test for ".a:file)
+  endif
+endfunction
+
+function s:TestWithLineFor(file)
+  let l:test_file = s:TestFor(a:file)
+  if a:file =~# '_test.exs$'
+    return l:test_file . ":" . line(".")
+  else
+    call s:error("can't determine matching line for ".l:test_file)
   endif
 endfunction
 


### PR DESCRIPTION
This will work like VimixTestCurrentFile, but append the current line number so
a test can be conveniently run in isolation.

It will produce an error when we are not currently in a test file, because in
this case we cannot really determine which line from the test file should run.

Let me know if this can be improved!

Cheers