### PR TITLE
Allow configuration of mix command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ session.  Key mappings are disabled by default, but can easily be enabled by set
 let g:vimix_map_keys = 1
 ```
 
+If you'd like run your tests in the context of [IEx](http://elixir-lang.org/docs/stable/iex/IEx.html) or change the way tests are run in other ways, you can customize the mix command like so:
+
+```vim
+let g:vimix_mix_command = "iex -S mix"
+```
+
+The default is just `mix`.
+
+
 ## Features
 
 * Changes Vimux runner directory to your mix project root (looks for the mix.exs file)

--- a/plugin/vimix.vim
+++ b/plugin/vimix.vim
@@ -7,6 +7,10 @@ if !exists('g:vimix_map_keys')
   let g:vimix_map_keys = 0
 endif
 
+if !exists('g:vimix_mix_command')
+  let g:vimix_mix_command = "mix"
+endif
+
 function! s:VimixFindMixRoot(dir)
   let dir = a:dir
   while ! filereadable(dir.'/mix.exs')
@@ -121,7 +125,7 @@ function s:VimixRunCommand(command)
     call VimuxRunCommand("cd ". shellescape(g:vimix_mix_root, 1))
     let g:vimix_in_mix_root = 1
   endif
-  call VimuxRunCommand("mix " . a:command)
+  call VimuxRunCommand(g:vimix_mix_command . " " . a:command)
 endfunction
 
 function! s:error(str)


### PR DESCRIPTION
This allows the tests to be run in the context of IEx or with any other options the user would like to use.
