### PR TITLE
Replace deprecated pseudo-private API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vimix
 
-[vimux](https://github.com/benmills/vimux) with [Elixir mix](https://github.com/elixir-lang/elixir) integration
+[vimux](https://github.com/preservim/vimux) with [Elixir mix](https://github.com/elixir-lang/elixir) integration
 
 ## Installation
 
@@ -50,7 +50,7 @@ Here are the key mappings for your reference:
 
 ## Requirements
 
-* [vimux](https://github.com/benmills/vimux)
+* [vimux](https://github.com/preservim/vimux)
 * [Elixir Language](https://github.com/elixir-lang/elixir)
 
 ## Contributing

--- a/plugin/vimix.vim
+++ b/plugin/vimix.vim
@@ -92,7 +92,7 @@ function VimixLocal()
 endfunction
 
 function VimixPromptCommand()
-  let l:command = input(_VimuxOption("g:VimixPromptString", "Mix Command? "))
+  let l:command = input('Mix Command? ')
   call s:VimixRunCommand(l:command)
 endfunction
 


### PR DESCRIPTION
The pseudo-private _VimuxOption function has been deprecated and an
official public VimuxOption method is available. However the way
defaults are handled is also changed. If you don't want to use the
default value, just don't. Hard coding the prompt here seems to make
more sense that even bothering to ask what the option value is.
